### PR TITLE
New configuration option amdModule for the compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ Option              | Description
 --------------------|------------------------------------------------------
 helpers             | Loads in DustJs helpers if they are available.
 infoNotice          | Show DustJs version number and if helpers are active.
+amdModule	    | Compile the templates as AMD modules. The templates will require the module 'dust.core' (as compiled by the dust template compile)
 
 Example:
 
 ```scala
 DustJsKeys.helpers in Assets := true
+DustJsKeys.amdModule in Assets := true
 ```
 
 ## Usage

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-dustjs-linkedin"
 
 organization := "com.jmparsons.sbt"
 
-version := "1.0.4"
+version := "1.0.5"
 
 sbtPlugin := true
 

--- a/src/main/resources/dust-shell.js
+++ b/src/main/resources/dust-shell.js
@@ -23,6 +23,10 @@
         console.error("DustJs: " + e);
     }
 
+    if (options.amdModule){
+	dust.config.amd = true;
+    }
+
     if (options.helpers) {
         try {
           require("dustjs-helpers");

--- a/src/main/scala/com/jmparsons/sbt/dustjs/SbtDustJs.scala
+++ b/src/main/scala/com/jmparsons/sbt/dustjs/SbtDustJs.scala
@@ -13,6 +13,7 @@ object Import {
 
     val helpers = SettingKey[Boolean]("dustjs-helpers", "Loads in DustJs helpers if they are available.")
     val infoNotice = SettingKey[Boolean]("dustjs-info-notice", "Show DustJs version number and if helpers are active.")
+    val amdModule = SettingKey[Boolean]("dustjs-amd-module", "Compile the templates as AMD modules.")
   }
 
 }
@@ -34,13 +35,15 @@ object SbtDustJs extends AutoPlugin {
     includeFilter := "*.tl",
     jsOptions := JsObject(
       "helpers" -> JsBoolean(helpers.value),
-      "infoNotice" -> JsBoolean(infoNotice.value)
+      "infoNotice" -> JsBoolean(infoNotice.value),
+      "amdModule" -> JsBoolean(amdModule.value)
     ).toString()
   )
 
   override def projectSettings = Seq(
     helpers := false,
-    infoNotice := false
+    infoNotice := false,
+    amdModule := false
   ) ++ inTask(dustjs)(
     SbtJsTask.jsTaskSpecificUnscopedSettings ++
       inConfig(Assets)(dustjsUnscopedSettings) ++


### PR DESCRIPTION
Added the configuration option amdModule to configure the compile to create amd loader compatible template files

The option is listed on https://github.com/linkedin/dustjs/wiki/Loading-Dust-via-AMD-(require.js).
I've tested this locally but don't know how to test this properly with a test case. I hope that this is useful :)
